### PR TITLE
Fixed broken image link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -17,7 +17,7 @@ If you're wondering how to contribute to the project, please refer to [CONTRIBUT
 ## License
 
 <p align="left">
-  <img width="40%" src="https://github.com/dahliaos/brand/blob/master/Logo%20PNGs/dahliaOS%20logo%20with%20text%20(drop%20shadow).png"
+  <img width="40%" src="https://github.com/dahliaOS/brand/blob/master/dahliaOS/svg/logotypeblacktext.svg"
 </p>
 
 Copyright @ 2019-2021 The dahliaOS Authors contact@dahliaos.io


### PR DESCRIPTION
## Description
The image link of the image under the "License" section was previously broken. The correct link was added, and the logo shows up now in the README

## Screenshots
Before: 

![image](https://user-images.githubusercontent.com/73262131/155920271-364816f0-cb06-4f5d-8ec8-dec0f22fe627.png)
After: 

![image](https://user-images.githubusercontent.com/73262131/155920306-8bdca669-472d-4849-9667-07b8f3b77c05.png)

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
